### PR TITLE
Check toml.el version, remove error on single quotes in Cargo.toml

### DIFF
--- a/verus-mode.el
+++ b/verus-mode.el
@@ -211,6 +211,11 @@ removed at any time."
 
 (defun verus--setup ()
   "Setup Verus mode."
+  (when (and (require 'toml nil 'noerror)
+             (not (fboundp 'toml:read-literal-string)))
+    (message (concat "Your toml.el package is outdated and may cause errors "
+                     "when reading Cargo.toml configuration.  Update with: "
+                     "M-x package-refresh-contents then M-x package-install RET toml")))
   (if (not verus-home)
       (setq verus-home (getenv "VERUS_HOME")))
   (if (or (not verus-home) (not (file-exists-p verus-home)))
@@ -365,11 +370,6 @@ This is done by checking if the file contains a `fn main` function."
            (insert-file-contents toml-file)
            (goto-char (point-min))
            (search-forward "verus" nil t)))
-    (when (with-temp-buffer
-          (insert-file-contents toml-file)
-          (goto-char (point-min))
-          (search-forward "'" nil t))
-      (error "The TOML parser does not like single quotes. Attempt updating your Cargo.toml file to use only double-quotes. See https://github.com/verus-lang/verus-mode.el/issues/9 for more details"))
     (let* ((toml (toml:read-from-file toml-file))
            (package (cdr (assoc "package" toml)))
            (metadata (cdr (assoc "metadata" package)))


### PR DESCRIPTION
Resolves #13

Removes the error on single quotes in Cargo.toml, and replaces it with a version check for toml.el. The removed error existed because toml.el lacked literal string support, but this was recently added in https://github.com/gongo/emacs-toml/pull/17.

Now checks for toml:read-literal-string function on startup and shows upgrade instructions if missing.