### PR TITLE
Use `cargo verus focus` when appropriate

### DIFF
--- a/test/integration-test.el
+++ b/test/integration-test.el
@@ -659,15 +659,7 @@ Uses the compilation exit status which works for both single crates and workspac
         (cons (flycheck-checker-executable 'verus-cargo)
               (flycheck-checker-substituted-arguments 'verus-cargo))
         '("cargo" "verus" "focus" "--message-format=json" "--"
-          "--verify-module" "foo::bar" "--expand-errors")))))
-  (cl-letf (((symbol-function 'verus--run-on-file-command)
-             (lambda () '("cargo" "verus" "verify" "--"))))
-    (should
-     (equal
-      (cons (flycheck-checker-executable 'verus-cargo)
-            (flycheck-checker-substituted-arguments 'verus-cargo))
-      '("cargo" "verus" "verify" "--message-format=json" "--"
-        "--expand-errors")))))
+          "--verify-module" "foo::bar" "--expand-errors"))))))
 
 ;;; verus-cargo-verus-arguments Tests
 

--- a/test/integration-test.el
+++ b/test/integration-test.el
@@ -616,26 +616,95 @@ Uses the compilation exit status which works for both single crates and workspac
                            (insert original-content)
                            (save-buffer)))))))
 
+;;; cargo-verus Command Tests
+
+(defmacro with-verus-test-cargo-verus-project (&rest body)
+  "Run BODY as though Cargo.toml describes a standalone cargo-verus project."
+  (declare (indent 0))
+  `(cl-letf (((symbol-function 'tomlparse-file)
+              (lambda (&rest _args)
+                '((package . ((metadata . ((verus . ((verify . t)))))))))))
+     ,@body))
+
+(ert-deftest verus-integration-test-cargo-verus-focus-module ()
+  "Test that cargo-verus uses focus when verifying a module."
+  :tags '(integration verification)
+  (skip-unless (file-exists-p (expand-file-name "cv-crate/src/foo/bar.rs" verus-test-examples-dir)))
+  (let ((file (expand-file-name "cv-crate/src/foo/bar.rs" verus-test-examples-dir)))
+    (with-verus-test-cargo-verus-project
+      (with-temp-buffer
+        (setq buffer-file-name file
+              default-directory (file-name-directory file))
+        (should (equal (verus--run-on-file-command)
+                       '("cargo" "verus" "focus" "--"
+                         "--verify-module" "foo::bar")))))))
+
+(ert-deftest verus-integration-test-cargo-verus-focus-root ()
+  "Test that cargo-verus uses focus when verifying a crate root."
+  :tags '(integration verification)
+  (skip-unless (file-exists-p (expand-file-name "cv-crate/src/lib.rs" verus-test-examples-dir)))
+  (let ((file (expand-file-name "cv-crate/src/lib.rs" verus-test-examples-dir)))
+    (with-verus-test-cargo-verus-project
+      (with-temp-buffer
+        (setq buffer-file-name file
+              default-directory (file-name-directory file))
+        (should (equal (verus--run-on-file-command)
+                       '("cargo" "verus" "focus" "--" "--verify-root")))))))
+
+(ert-deftest verus-integration-test-cargo-verus-focus-function ()
+  "Test that cargo-verus uses focus when verifying a function."
+  :tags '(integration verification)
+  (skip-unless (file-exists-p (expand-file-name "cv-crate/src/foo/bar.rs" verus-test-examples-dir)))
+  (let ((file (expand-file-name "cv-crate/src/foo/bar.rs" verus-test-examples-dir)))
+    (with-verus-test-cargo-verus-project
+      (with-temp-buffer
+        (insert-file-contents file)
+        (setq buffer-file-name file
+              default-directory (file-name-directory file))
+        (should (equal (verus--run-on-function-command "test")
+                       '("cargo" "verus" "focus" "--"
+                         "--verify-only-module" "foo::bar"
+                         "--verify-function" "test")))))))
+
+(ert-deftest verus-integration-test-cargo-verus-flycheck-subcommand ()
+  "Test that Flycheck uses the subcommand selected for file verification."
+  :tags '(integration flycheck verification)
+  (skip-unless (file-exists-p (expand-file-name "cv-crate/src/foo/bar.rs" verus-test-examples-dir)))
+  (let ((file (expand-file-name "cv-crate/src/foo/bar.rs" verus-test-examples-dir)))
+    (with-verus-test-cargo-verus-project
+      (with-temp-buffer
+        (setq buffer-file-name file
+              default-directory (file-name-directory file))
+        (should
+         (equal
+          (cons (flycheck-checker-executable 'verus-cargo)
+                (flycheck-checker-substituted-arguments 'verus-cargo))
+          '("cargo" "verus" "focus" "--message-format=json" "--"
+            "--verify-module" "foo::bar" "--expand-errors"))))))
+  (cl-letf (((symbol-function 'verus--run-on-file-command)
+             (lambda () '("cargo" "verus" "verify" "--"))))
+    (should
+     (equal
+      (cons (flycheck-checker-executable 'verus-cargo)
+            (flycheck-checker-substituted-arguments 'verus-cargo))
+      '("cargo" "verus" "verify" "--message-format=json" "--"
+        "--expand-errors")))))
+
 ;;; verus-cargo-verus-arguments Tests
 
 (ert-deftest verus-integration-test-cargo-verus-arguments ()
-  "Test that verus-cargo-verus-arguments are passed through to the compile command."
+  "Test that verus-cargo-verus-arguments are passed through to the command."
   :tags '(integration verification)
   (skip-unless (file-exists-p (expand-file-name "cv-crate/src/lib.rs" verus-test-examples-dir)))
-  (let ((file (expand-file-name "cv-crate/src/lib.rs" verus-test-examples-dir))
-        (captured-command nil))
-    (with-verus-file file
-      (let ((verus-cargo-verus-arguments '("--" "--expand-errors")))
-        (cl-flet ((capture-command (command &rest _)
-                    (setq captured-command command)))
-          (unwind-protect
-              (progn
-                (advice-add 'compile :before #'capture-command)
-                (verus-run-on-file 1)
-                (verus-test-wait-for-compilation))
-            (advice-remove 'compile #'capture-command))))
-      (should (stringp captured-command))
-      (should (string-match-p "^cargo verus verify -- --expand-errors" captured-command)))))
+  (let ((file (expand-file-name "cv-crate/src/lib.rs" verus-test-examples-dir)))
+    (with-verus-test-cargo-verus-project
+      (with-temp-buffer
+        (setq buffer-file-name file
+              default-directory (file-name-directory file))
+        (let ((verus-cargo-verus-arguments '("--" "--expand-errors")))
+          (should (equal (verus--run-on-file-command)
+                         '("cargo" "verus" "focus" "--" "--expand-errors"
+                           "--verify-root"))))))))
 
 ;;; Run All Integration Tests
 

--- a/test/integration-test.el
+++ b/test/integration-test.el
@@ -618,69 +618,48 @@ Uses the compilation exit status which works for both single crates and workspac
 
 ;;; cargo-verus Command Tests
 
-(defmacro with-verus-test-cargo-verus-project (&rest body)
-  "Run BODY as though Cargo.toml describes a standalone cargo-verus project."
-  (declare (indent 0))
-  `(cl-letf (((symbol-function 'tomlparse-file)
-              (lambda (&rest _args)
-                '((package . ((metadata . ((verus . ((verify . t)))))))))))
-     ,@body))
-
 (ert-deftest verus-integration-test-cargo-verus-focus-module ()
   "Test that cargo-verus uses focus when verifying a module."
   :tags '(integration verification)
   (skip-unless (file-exists-p (expand-file-name "cv-crate/src/foo/bar.rs" verus-test-examples-dir)))
   (let ((file (expand-file-name "cv-crate/src/foo/bar.rs" verus-test-examples-dir)))
-    (with-verus-test-cargo-verus-project
-      (with-temp-buffer
-        (setq buffer-file-name file
-              default-directory (file-name-directory file))
-        (should (equal (verus--run-on-file-command)
-                       '("cargo" "verus" "focus" "--"
-                         "--verify-module" "foo::bar")))))))
+    (with-verus-file file
+      (should (equal (verus--run-on-file-command)
+                     '("cargo" "verus" "focus" "--"
+                       "--verify-module" "foo::bar"))))))
 
 (ert-deftest verus-integration-test-cargo-verus-focus-root ()
   "Test that cargo-verus uses focus when verifying a crate root."
   :tags '(integration verification)
   (skip-unless (file-exists-p (expand-file-name "cv-crate/src/lib.rs" verus-test-examples-dir)))
   (let ((file (expand-file-name "cv-crate/src/lib.rs" verus-test-examples-dir)))
-    (with-verus-test-cargo-verus-project
-      (with-temp-buffer
-        (setq buffer-file-name file
-              default-directory (file-name-directory file))
-        (should (equal (verus--run-on-file-command)
-                       '("cargo" "verus" "focus" "--" "--verify-root")))))))
+    (with-verus-file file
+      (should (equal (verus--run-on-file-command)
+                     '("cargo" "verus" "focus" "--" "--verify-root"))))))
 
 (ert-deftest verus-integration-test-cargo-verus-focus-function ()
   "Test that cargo-verus uses focus when verifying a function."
   :tags '(integration verification)
   (skip-unless (file-exists-p (expand-file-name "cv-crate/src/foo/bar.rs" verus-test-examples-dir)))
   (let ((file (expand-file-name "cv-crate/src/foo/bar.rs" verus-test-examples-dir)))
-    (with-verus-test-cargo-verus-project
-      (with-temp-buffer
-        (insert-file-contents file)
-        (setq buffer-file-name file
-              default-directory (file-name-directory file))
-        (should (equal (verus--run-on-function-command "test")
-                       '("cargo" "verus" "focus" "--"
-                         "--verify-only-module" "foo::bar"
-                         "--verify-function" "test")))))))
+    (with-verus-file file
+      (should (equal (verus--run-on-function-command "test")
+                     '("cargo" "verus" "focus" "--"
+                       "--verify-only-module" "foo::bar"
+                       "--verify-function" "test"))))))
 
 (ert-deftest verus-integration-test-cargo-verus-flycheck-subcommand ()
   "Test that Flycheck uses the subcommand selected for file verification."
   :tags '(integration flycheck verification)
   (skip-unless (file-exists-p (expand-file-name "cv-crate/src/foo/bar.rs" verus-test-examples-dir)))
   (let ((file (expand-file-name "cv-crate/src/foo/bar.rs" verus-test-examples-dir)))
-    (with-verus-test-cargo-verus-project
-      (with-temp-buffer
-        (setq buffer-file-name file
-              default-directory (file-name-directory file))
-        (should
-         (equal
-          (cons (flycheck-checker-executable 'verus-cargo)
-                (flycheck-checker-substituted-arguments 'verus-cargo))
-          '("cargo" "verus" "focus" "--message-format=json" "--"
-            "--verify-module" "foo::bar" "--expand-errors"))))))
+    (with-verus-file file
+      (should
+       (equal
+        (cons (flycheck-checker-executable 'verus-cargo)
+              (flycheck-checker-substituted-arguments 'verus-cargo))
+        '("cargo" "verus" "focus" "--message-format=json" "--"
+          "--verify-module" "foo::bar" "--expand-errors")))))
   (cl-letf (((symbol-function 'verus--run-on-file-command)
              (lambda () '("cargo" "verus" "verify" "--"))))
     (should
@@ -697,14 +676,11 @@ Uses the compilation exit status which works for both single crates and workspac
   :tags '(integration verification)
   (skip-unless (file-exists-p (expand-file-name "cv-crate/src/lib.rs" verus-test-examples-dir)))
   (let ((file (expand-file-name "cv-crate/src/lib.rs" verus-test-examples-dir)))
-    (with-verus-test-cargo-verus-project
-      (with-temp-buffer
-        (setq buffer-file-name file
-              default-directory (file-name-directory file))
-        (let ((verus-cargo-verus-arguments '("--" "--expand-errors")))
-          (should (equal (verus--run-on-file-command)
-                         '("cargo" "verus" "focus" "--" "--expand-errors"
-                           "--verify-root"))))))))
+    (with-verus-file file
+      (let ((verus-cargo-verus-arguments '("--" "--expand-errors")))
+        (should (equal (verus--run-on-file-command)
+                       '("cargo" "verus" "focus" "--" "--expand-errors"
+                         "--verify-root")))))))
 
 ;;; Run All Integration Tests
 

--- a/verus-examples/cv-crate/Cargo.lock
+++ b/verus-examples/cv-crate/Cargo.lock
@@ -3,10 +3,10 @@
 version = 4
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
+name = "convert_case"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cv-crate"
@@ -16,18 +16,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
- "autocfg",
+ "equivalent",
  "hashbrown",
 ]
 
@@ -79,16 +85,17 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verus_builtin"
-version = "0.0.0-2026-02-08-0120"
+version = "0.0.0-2026-08-09-0044"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1bd13abb198fff161cf4be16cf8c1723f09941d03e323af71146fa4cfb0de0f"
+checksum = "f5f2985ebd252c492375e32f2bfcff6e6a04523009a0d624785d3468f3729158"
 
 [[package]]
 name = "verus_builtin_macros"
-version = "0.0.0-2026-02-22-0103"
+version = "0.0.0-2026-08-09-0044"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe750a656777699bfdcfee3894cc24f04b6f276e1240b2c9dbdeccdae4e5d94e"
+checksum = "57091b5661094900006f07621654a455ecf8ab40efc22981cb39b773ff7bc21c"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn",
@@ -99,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "verus_prettyplease"
-version = "0.0.0-2026-02-15-0106"
+version = "0.0.0-2026-08-09-0044"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1c9a8d5635aac38528868312f72ed3f0e76f58ca25ac5c407d1064bdc33430"
+checksum = "51fc115de5fb3806bc362060bb683024660ed2bc13c1183d1f01d464e4537139"
 dependencies = [
  "proc-macro2",
  "verus_syn",
@@ -109,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "verus_state_machines_macros"
-version = "0.0.0-2026-02-15-0106"
+version = "0.0.0-2026-08-02-0125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28cb0ec7d66fc27adccbd5aa9d96acf3ab5508cd97f1ca8930fed4f272f6ba8"
+checksum = "93f77ff8d121edb1bf2651335769a80a2f611da8573c3b498434a66b3162805f"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -121,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "verus_syn"
-version = "0.0.0-2026-02-15-0106"
+version = "0.0.0-2026-08-02-0125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fbe9986fe3ffe05a07a87834a6a2400792e52969813fa9660e313e1c9eda6b7"
+checksum = "f17237ea6d267e457d53ce36f55b315fc9edd26eb88c765dd95e035c0b415869"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -132,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "vstd"
-version = "0.0.0-2026-02-22-0103"
+version = "0.0.0-2026-08-09-0044"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b74abf6d04d21b8898894960d11dbe2489ab48be1f24eca92821b865616910c"
+checksum = "512e38f177f75c473a03121bf0934a276468f78fea84c073f979d6670e862705"
 dependencies = [
  "verus_builtin",
  "verus_builtin_macros",

--- a/verus-examples/cv-crate/Cargo.toml
+++ b/verus-examples/cv-crate/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vstd = "=0.0.0-2026-02-22-0103"
+vstd = "=0.0.0-2026-08-09-0044"
 
 [package.metadata.verus]
 verify = true

--- a/verus-examples/cv-workspace/Cargo.lock
+++ b/verus-examples/cv-workspace/Cargo.lock
@@ -3,24 +3,30 @@
 version = 4
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
+name = "convert_case"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
- "autocfg",
+ "equivalent",
  "hashbrown",
 ]
 
@@ -86,16 +92,17 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verus_builtin"
-version = "0.0.0-2026-02-08-0120"
+version = "0.0.0-2026-08-09-0044"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1bd13abb198fff161cf4be16cf8c1723f09941d03e323af71146fa4cfb0de0f"
+checksum = "f5f2985ebd252c492375e32f2bfcff6e6a04523009a0d624785d3468f3729158"
 
 [[package]]
 name = "verus_builtin_macros"
-version = "0.0.0-2026-02-22-0103"
+version = "0.0.0-2026-08-09-0044"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe750a656777699bfdcfee3894cc24f04b6f276e1240b2c9dbdeccdae4e5d94e"
+checksum = "57091b5661094900006f07621654a455ecf8ab40efc22981cb39b773ff7bc21c"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn",
@@ -106,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "verus_prettyplease"
-version = "0.0.0-2026-02-15-0106"
+version = "0.0.0-2026-08-09-0044"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1c9a8d5635aac38528868312f72ed3f0e76f58ca25ac5c407d1064bdc33430"
+checksum = "51fc115de5fb3806bc362060bb683024660ed2bc13c1183d1f01d464e4537139"
 dependencies = [
  "proc-macro2",
  "verus_syn",
@@ -116,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "verus_state_machines_macros"
-version = "0.0.0-2026-02-15-0106"
+version = "0.0.0-2026-08-02-0125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28cb0ec7d66fc27adccbd5aa9d96acf3ab5508cd97f1ca8930fed4f272f6ba8"
+checksum = "93f77ff8d121edb1bf2651335769a80a2f611da8573c3b498434a66b3162805f"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -128,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "verus_syn"
-version = "0.0.0-2026-02-15-0106"
+version = "0.0.0-2026-08-02-0125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fbe9986fe3ffe05a07a87834a6a2400792e52969813fa9660e313e1c9eda6b7"
+checksum = "f17237ea6d267e457d53ce36f55b315fc9edd26eb88c765dd95e035c0b415869"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -139,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "vstd"
-version = "0.0.0-2026-02-22-0103"
+version = "0.0.0-2026-08-09-0044"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b74abf6d04d21b8898894960d11dbe2489ab48be1f24eca92821b865616910c"
+checksum = "512e38f177f75c473a03121bf0934a276468f78fea84c073f979d6670e862705"
 dependencies = [
  "verus_builtin",
  "verus_builtin_macros",

--- a/verus-examples/cv-workspace/member1/Cargo.toml
+++ b/verus-examples/cv-workspace/member1/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vstd = "=0.0.0-2026-02-22-0103"
+vstd = "=0.0.0-2026-08-09-0044"
 
 [package.metadata.verus]
 verify = true

--- a/verus-examples/cv-workspace/member2/Cargo.toml
+++ b/verus-examples/cv-workspace/member2/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vstd = "=0.0.0-2026-02-22-0103"
+vstd = "=0.0.0-2026-08-09-0044"
 
 [package.metadata.verus]
 verify = true

--- a/verus-mode.el
+++ b/verus-mode.el
@@ -565,17 +565,13 @@ When `verus-cargo-verus-arguments' is non-nil it is appended in place of the
 default `--' separator.  The list must contain `--' at the appropriate
 position; an error is signalled otherwise."
   (let ((subcommand (or subcommand "verify")))
-    (if verus-cargo-verus-arguments
-        (progn
-          (unless (member "--" verus-cargo-verus-arguments)
-            (error "verus-cargo-verus-arguments must contain \"--\" to separate \
+    (when (and verus-cargo-verus-arguments
+               (not (member "--" verus-cargo-verus-arguments)))
+      (error "verus-cargo-verus-arguments must contain \"--\" to separate \
 cargo-verus flags from Verus flags (e.g. (\"--features\" \"foo\" \"--\" \"--expand-errors\"))"))
-          (append (list "cargo" "verus" subcommand)
-                  (when package (list "-p" package))
-                  verus-cargo-verus-arguments))
-      (append (list "cargo" "verus" subcommand)
-              (when package (list "-p" package))
-              (list "--")))))
+    (append (list "cargo" "verus" subcommand)
+            (when package (list "-p" package))
+            (or verus-cargo-verus-arguments (list "--")))))
 
 (defun verus--run-on-crate-command (&optional cargo-verus-subcommand)
   "Return the command to run Verus on the current crate.

--- a/verus-mode.el
+++ b/verus-mode.el
@@ -167,12 +167,12 @@ removed at any time."
   :type 'boolean)
 
 (defcustom verus-cargo-verus-arguments nil
-  "Extra arguments to pass to `cargo verus verify', as a list of strings.
+  "Extra arguments to pass to cargo-verus commands, as a list of strings.
 
-When non-nil, this list is appended directly to the `cargo verus verify'
-invocation instead of the default `--' separator.  The list MUST contain
-`--' at the correct position to separate cargo-verus flags from Verus
-flags; an error is signalled if it does not.
+When non-nil, this list is appended directly to the `cargo verus verify' or
+`cargo verus focus' invocation instead of the default `--' separator.  The
+list MUST contain `--' at the correct position to separate cargo-verus flags
+from Verus flags; an error is signalled if it does not.
 
 Example `.dir-locals.el' usage:
 
@@ -555,28 +555,33 @@ Returns the package name as a string, or nil if not found."
            (name (cdr (assoc 'name package))))
       name)))
 
-(defun verus--cargo-verus-command (&optional package)
+(defun verus--cargo-verus-command (&optional package subcommand)
   "Build cargo-verus command.
 If PACKAGE is non-nil, adds -p PACKAGE to target a specific workspace member.
-Returns a list of command-line arguments for cargo verus verify.
+SUBCOMMAND defaults to `verify'.
+Returns a list of command-line arguments for cargo verus SUBCOMMAND.
 
 When `verus-cargo-verus-arguments' is non-nil it is appended in place of the
 default `--' separator.  The list must contain `--' at the appropriate
 position; an error is signalled otherwise."
-  (if verus-cargo-verus-arguments
-      (progn
-        (unless (member "--" verus-cargo-verus-arguments)
-          (error "verus-cargo-verus-arguments must contain \"--\" to separate \
+  (let ((subcommand (or subcommand "verify")))
+    (if verus-cargo-verus-arguments
+        (progn
+          (unless (member "--" verus-cargo-verus-arguments)
+            (error "verus-cargo-verus-arguments must contain \"--\" to separate \
 cargo-verus flags from Verus flags (e.g. (\"--features\" \"foo\" \"--\" \"--expand-errors\"))"))
-        (append (list "cargo" "verus" "verify")
-                (when package (list "-p" package))
-                verus-cargo-verus-arguments))
-    (append (list "cargo" "verus" "verify")
-            (when package (list "-p" package))
-            (list "--"))))
+          (append (list "cargo" "verus" subcommand)
+                  (when package (list "-p" package))
+                  verus-cargo-verus-arguments))
+      (append (list "cargo" "verus" subcommand)
+              (when package (list "-p" package))
+              (list "--")))))
 
-(defun verus--run-on-crate-command ()
+(defun verus--run-on-crate-command (&optional cargo-verus-subcommand)
   "Return the command to run Verus on the current crate.
+
+If CARGO-VERUS-SUBCOMMAND is non-nil, use it instead of `verify' for
+cargo-verus projects.
 
 Returns a list of command-line arguments. Expects to be run in a
 buffer visiting the file, otherwise throws an error."
@@ -594,7 +599,7 @@ buffer visiting the file, otherwise throws an error."
                  ;; If in a workspace, get the package name from the current crate's Cargo.toml
                  (package-name (when workspace-root
                                  (verus--get-package-name cargo-toml))))
-            (verus--cargo-verus-command package-name))
+                (verus--cargo-verus-command package-name cargo-verus-subcommand))
         (append
          (list verus--rust-verify)
          (if (string-suffix-p "lib.rs" crate-root)
@@ -631,15 +636,17 @@ buffer visiting the file, otherwise throws an error."
     ;; Use the file's directory as default-directory for finding crate root,
     ;; since the caller may have set default-directory to the workspace root
     (let ((default-directory (f-dirname file)))
-      (append
-       (verus--run-on-crate-command)
-       (cond
-        ;; In workspace: skip subsetting arguments due to issue verus#1938
-        ((verus--is-in-cargo-verus-workspace) nil)
-        ((string= file (verus--crate-root-file))
-         (list "--verify-root"))
-        (t
-         (list "--verify-module" (verus--current-module-name))))))))
+      (let ((verify-args
+             (cond
+              ;; In workspace: skip subsetting arguments due to issue verus#1938
+              ((verus--is-in-cargo-verus-workspace) nil)
+              ((string= file (verus--crate-root-file))
+               (list "--verify-root"))
+              (t
+               (list "--verify-module" (verus--current-module-name))))))
+        (append
+         (verus--run-on-crate-command (when verify-args "focus"))
+         verify-args)))))
 
 (defun verus-run-on-crate (prefix)
   "Run Verus on the current crate.
@@ -691,8 +698,10 @@ If PREFIX is non-nil, then enable `always profiling' mode."
 
 Returns a list of command-line arguments. If FUNCTION-NAME is nil,
 returns base command for manual function specification."
-  (let ((base-command (verus--run-on-crate-command)))
-    (if (verus--is-in-cargo-verus-workspace)
+  (let* ((in-workspace (verus--is-in-cargo-verus-workspace))
+         (base-command (verus--run-on-crate-command
+                        (unless in-workspace "focus"))))
+    (if in-workspace
         (progn
           (message "Function/module subsetting is unsupported on workspace crates until https://github.com/verus-lang/verus/issues/1938 is resolved. Verifying entire workspace instead.")
           base-command)
@@ -744,15 +753,15 @@ If PREFIX is non-nil, then confirm command to run before running it."
 ;;; Flycheck setup
 
 (flycheck-define-checker verus-cargo
-  "A Verus syntax checker using cargo verus verify."
+  "A Verus syntax checker using cargo-verus."
   :command ("cargo"
             "verus"
-            "verify"
+            (eval (nth 2 (verus--run-on-file-command)))
             (eval
              ;; Extract -p flag and package name if present
              (let* ((full-cmd (verus--run-on-file-command))
                     (dash-dash-pos (cl-position "--" full-cmd :test #'string=))
-                    ;; Get everything between "verify" and "--"
+                    ;; Get everything between the subcommand and "--"
                     (cargo-flags (when dash-dash-pos
                                    (cl-subseq full-cmd 3 dash-dash-pos))))
                cargo-flags))

--- a/verus-mode.el
+++ b/verus-mode.el
@@ -595,7 +595,7 @@ buffer visiting the file, otherwise throws an error."
                  ;; If in a workspace, get the package name from the current crate's Cargo.toml
                  (package-name (when workspace-root
                                  (verus--get-package-name cargo-toml))))
-                (verus--cargo-verus-command package-name cargo-verus-subcommand))
+            (verus--cargo-verus-command package-name cargo-verus-subcommand))
         (append
          (list verus--rust-verify)
          (if (string-suffix-p "lib.rs" crate-root)

--- a/verus-mode.el
+++ b/verus-mode.el
@@ -631,18 +631,19 @@ buffer visiting the file, otherwise throws an error."
       (error "Buffer is not visiting a file. Cannot run Verus"))
     ;; Use the file's directory as default-directory for finding crate root,
     ;; since the caller may have set default-directory to the workspace root
-    (let ((default-directory (f-dirname file)))
-      (let ((verify-args
-             (cond
-              ;; In workspace: skip subsetting arguments due to issue verus#1938
-              ((verus--is-in-cargo-verus-workspace) nil)
-              ((string= file (verus--crate-root-file))
-               (list "--verify-root"))
-              (t
-               (list "--verify-module" (verus--current-module-name))))))
-        (append
-         (verus--run-on-crate-command (when verify-args "focus"))
-         verify-args)))))
+    (let* ((default-directory (f-dirname file))
+           (verify-args
+            (cond
+             ;; In workspace: skip subsetting arguments due to issue verus#1938
+             ((verus--is-in-cargo-verus-workspace) nil)
+             ((string= file (verus--crate-root-file))
+              (list "--verify-root"))
+             (t
+              (list "--verify-module" (verus--current-module-name))))))
+      (append
+       ;; Use `focus' exactly when we pass subsetting arguments.
+       (verus--run-on-crate-command (when verify-args "focus"))
+       verify-args))))
 
 (defun verus-run-on-crate (prefix)
   "Run Verus on the current crate.


### PR DESCRIPTION
A change is coming soon to Verus to disallow use of `--verify-module`, `--verify-function`, and `--verify-root` with `cargo verus verify`. Instead, one is expected to use `cargo verus focus`. This PR updates `verus-mode` to use `focus` when appropriate.

The discussion at https://github.com/verus-lang/verus/issues/2799 explains why these arguments are a bad idea when using `cargo verus verify`. Essentially, doing so pollutes cargo's cache, confusing it about which modules have been verified. One goal of `cargo verus focus` is to isolate the partial verification so it doesn't pollute this way.

This code was written by GPT-5.6 Sol, prompted by someone who's not very familiar with Emacs Lisp and thus unable to audit it properly. So it may very well have bugs.